### PR TITLE
fix multi-select

### DIFF
--- a/clipboard.py
+++ b/clipboard.py
@@ -33,7 +33,7 @@ class ClipboardDisplayCommand(sublime_plugin.TextCommand):
 # support it. This lets us respond to ctrl-c and ctrl-x, without having
 # to re-implement the copy and cut commands. (Important, since
 # run_command("copy") doesn't do anything.)
-class ClipboardListner(sublime_plugin.EventListener):
+class ClipboardListener(sublime_plugin.EventListener):
     def on_query_context(self, view, key, *args):
         if key != "clipboardcopy_fake":
             return None

--- a/clipboard.py
+++ b/clipboard.py
@@ -38,7 +38,6 @@ class ClipboardListner(sublime_plugin.EventListener):
         if key != "clipboardcopy_fake":
             return None
         for selected in view.sel():
-            selected = view.sel()[0]
             if selected.empty():
                 selected = view.line(selected)
 


### PR DESCRIPTION
The first fixes multi-selection copying. (Really cool.)

The second patch is a spelling fix - may require a restart of Sublime, as the previous misspelled listener is not deregistered on reload.
