### PR TITLE
shift picked pastes to the top

### DIFF
--- a/clipboard.py
+++ b/clipboard.py
@@ -22,7 +22,14 @@ class ClipboardDisplayCommand(sublime_plugin.TextCommand):
 
         s = sublime.load_settings("ClipboardHistory.sublime-settings")
 
-        sublime.set_clipboard(history[picked])
+        # swap picked paste to the top
+        if picked == 0:
+            text = history[0]
+        else:
+            text = history.pop(picked)
+            history.insert(0, text)
+
+        sublime.set_clipboard(text)
         if s.get('paste_and_indent'):
             self.view.run_command('paste_and_indent')
         else:


### PR DESCRIPTION
Sorta like a LRU - least used pastes slowly accumulate at the back of `history`, so that the `limit` culling removes them, instead of old-copied, yet recently-used pastes.
