### PR TITLE
Paste previous and Paste next commands

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -5,5 +5,7 @@
 	{ "keys": ["ctrl+x"], "command": "clipboard_copy",
 		"context": [{"key": "clipboardcopy_fake", "operator":"equal", "operand":true}]
 	},
-	{ "keys": ["ctrl+alt+v"], "command": "clipboard_display" }
+	{ "keys": ["ctrl+alt+v"], "command": "clipboard_display" },
+	{ "keys": ["ctrl+shift+v"], "command": "clipboard_paste_previous" },
+	{ "keys": ["ctrl+shift+alt+v"], "command": "clipboard_paste_next" }
 ]

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -5,5 +5,7 @@
 	{ "keys": ["super+x"], "command": "clipboard_copy",
 		"context": [{"key": "clipboardcopy_fake", "operator":"equal", "operand":true}]
 	},
-	{ "keys": ["ctrl+alt+command+v"], "command": "clipboard_display" }
+	{ "keys": ["super+ctrl+alt+v"], "command": "clipboard_display" },
+	{ "keys": ["super+shift+v"], "command": "clipboard_paste_previous" },
+	{ "keys": ["super+shift+alt+v"], "command": "clipboard_paste_next" }
 ]

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -5,5 +5,7 @@
 	{ "keys": ["ctrl+x"], "command": "clipboard_copy",
 		"context": [{"key": "clipboardcopy_fake", "operator":"equal", "operand":true}]
 	},
-	{ "keys": ["ctrl+alt+v"], "command": "clipboard_display" }
+	{ "keys": ["ctrl+alt+v"], "command": "clipboard_display" },
+	{ "keys": ["ctrl+shift+v"], "command": "clipboard_paste_previous" },
+	{ "keys": ["ctrl+shift+alt+v"], "command": "clipboard_paste_next" }
 ]

--- a/README.markdown
+++ b/README.markdown
@@ -4,16 +4,24 @@ Keep a history of your clipboard items. Let you paste them back in, as needed.
 
 ## Using
 
-OSX: Press ctrl-alt-super-v to show the history.
+### OSX
 
-Windows:  Press ctrl-alt-v to show the history.
+ * Press ⌘⎇⌃V to show the history.
+ * Press ⌘⇧V to paste the previous (older) history entry.
+ * Press ⌘⇧⎇V to paste the next (newer) history entry.
+
+### Windows & Linux:
+
+ * Press ctrl-alt-v to show the history.
+ * Press ctrl-shift-v to paste the previous (older) history entry.
+ * Press ctrl-shift-alt-v to paste the next (newer) history entry.
 
 ## Limitations
 
 The history will only contain items that were copied:
 
  * in Sublime Text
- * using ctrl-c or ctrl-x (*not* the menu items)
+ * using ctrl-c/⌘C or ctrl-x/⌘X (*not* the menu items)
 
 Anything that reloads the plugin will clear the saved history.
 

--- a/clipboard.py
+++ b/clipboard.py
@@ -4,6 +4,7 @@ import sublime
 import sublime_plugin
 
 history = []
+history_index = 0
 
 
 class ClipboardDisplayCommand(sublime_plugin.TextCommand):
@@ -17,8 +18,11 @@ class ClipboardDisplayCommand(sublime_plugin.TextCommand):
         self.view.window().show_quick_panel(summary, self.panel_done)
 
     def panel_done(self, picked):
+        global history_index
         if 0 > picked < len(history):
             return
+
+        history_index = picked
 
         s = sublime.load_settings("ClipboardHistory.sublime-settings")
 
@@ -28,6 +32,33 @@ class ClipboardDisplayCommand(sublime_plugin.TextCommand):
         else:
             self.view.run_command('paste')
 
+class ClipboardPastePreviousCommand(sublime_plugin.TextCommand):
+    def run(self, edit):
+        global history_index
+        if history:
+            history_index = min(history_index + 1, len(history) - 1)
+            sublime.set_clipboard(history[history_index])
+
+        s = sublime.load_settings("ClipboardHistory.sublime-settings")
+
+        if s.get('paste_and_indent'):
+            self.view.run_command('paste_and_indent')
+        else:
+            self.view.run_command('paste')
+
+class ClipboardPasteNextCommand(sublime_plugin.TextCommand):
+    def run(self, edit):
+        global history_index
+        if history:
+            history_index = max(history_index - 1, 0)
+            sublime.set_clipboard(history[history_index])
+
+        s = sublime.load_settings("ClipboardHistory.sublime-settings")
+
+        if s.get('paste_and_indent'):
+            self.view.run_command('paste_and_indent')
+        else:
+            self.view.run_command('paste')
 
 # Here we see a cunning plan. We listen for a key, but never say we
 # support it. This lets us respond to ctrl-c and ctrl-x, without having
@@ -35,6 +66,7 @@ class ClipboardDisplayCommand(sublime_plugin.TextCommand):
 # run_command("copy") doesn't do anything.)
 class ClipboardListner(sublime_plugin.EventListener):
     def on_query_context(self, view, key, *args):
+        global history_index
         if key != "clipboardcopy_fake":
             return None
         for selected in view.sel():
@@ -46,6 +78,7 @@ class ClipboardListner(sublime_plugin.EventListener):
 
             if not history or history[0] != text:
                 history.insert(0, text)
+                history_index = 0
 
         s = sublime.load_settings("ClipboardHistory.sublime-settings")
         if s.get("limit") < len(history):


### PR DESCRIPTION
Added Cmd+Shift+V/Ctrl+Shift+V to paste previous history item and Cmd+Shift+Alt+V/Ctrl+Shift+Alt+V to paste next history item (à la TextMate).
