### PR TITLE
Reorder history on paste.

### DIFF
--- a/clipboard.py
+++ b/clipboard.py
@@ -20,8 +20,11 @@ class ClipboardDisplayCommand(sublime_plugin.TextCommand):
         if 0 > picked < len(history):
             return
 
-        s = sublime.load_settings("ClipboardHistory.sublime-settings")
+        str_to_paste = history[picked]
+        del history[picked]
+        history.insert(0, str_to_paste)
 
+        s = sublime.load_settings("ClipboardHistory.sublime-settings")
         sublime.set_clipboard(history[picked])
         if s.get('paste_and_indent'):
             self.view.run_command('paste_and_indent')


### PR DESCRIPTION
Thanks for making a handy clipboard plugin. I found that this change helped make it easier to use locally. If you agree, then please take a look :)

When pasting an item, that item should move to the top of the the history list. This makes repeated pastes much quicker.
